### PR TITLE
load zfpga firmware automatically

### DIFF
--- a/conf/machine/include/tune-gfex-zynqmp.inc
+++ b/conf/machine/include/tune-gfex-zynqmp.inc
@@ -14,12 +14,11 @@ EXTRA_IMAGEDEPENDS += " \
     virtual/pmu-firmware \
     "
 
-# image for SPI
-IMAGE_FSTYPES += "jffs2"
-JFFS2_ERASEBLOCK = "0x20000"
+YAML_ENABLE_DT_OVERLAY = "1"
 
-# image for SD card
-IMAGE_FSTYPES += "wic"
+# image for SPI
+IMAGE_FSTYPES += "jffs2 ext4 wic"
+JFFS2_ERASEBLOCK = "0x20000"
 WKS_FILES = "gfex-sdimage.wks"
 
 # disable SPL

--- a/recipes-core/images/core-image-gfex.bb
+++ b/recipes-core/images/core-image-gfex.bb
@@ -21,7 +21,7 @@ IMAGE_INSTALL_append_gfex-production += "init-ironman"
 IMAGE_INSTALL_append_gfex-production += "init-opc-server"
 IMAGE_INSTALL_append_gfex-production += "init-log-manager"
 IMAGE_INSTALL_append_gfex-production += "init-resize-rootfs"
-
+IMAGE_INSTALL_append_gfex-production += "init-load-firmware"
 
 #IMAGE_INSTALL_append_zynqmp += "gator glew"
 

--- a/recipes-core/init/init-load-firmware/LICENSE
+++ b/recipes-core/init/init-load-firmware/LICENSE
@@ -1,0 +1,18 @@
+# Copyright 2022 Emily Smith Permission is hereby granted, free of charge, to
+# any person obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/recipes-core/init/init-load-firmware/load-firmware.py
+++ b/recipes-core/init/init-load-firmware/load-firmware.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import os, subprocess
+
+
+ENABLE_FIRMWARE_LOAD = False
+
+
+if ENABLE_FIRMWARE_LOAD:
+    
+    load = "not empty" 
+    while (load != ""):
+
+        prep = subprocess.getoutput("echo 0 > /sys/class/fpga_manager/fpga0/flags")
+        load = subprocess.getoutput("echo zfpga_top.bit > /sys/class/fpga_manager/fpga0/firmware")
+        print(load)
+
+    print("Loaded firmware on zFPGA using /lib/firmware/zfpga_top.bit")
+
+else:
+    print("Did not load any firmware on the zFPGA")
+

--- a/recipes-core/init/init-load-firmware_0.0.0.bb
+++ b/recipes-core/init/init-load-firmware_0.0.0.bb
@@ -1,0 +1,32 @@
+DESCRIPTION = "Load user firmware on zFPGA"
+SRC_URI_gfex-production = "\
+  file://load-firmware.py \
+  file://zfpga_top.bit \
+  file://LICENSE \
+"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;beginline=1;endline=18;md5=470c8811ac7dbd16d782e1422760fad8"
+
+COMPATIBLE_MACHINE = "gfex-prototype4"
+
+# these 3 lines will have the script run on boot
+inherit update-rc.d
+INITSCRIPT_PACKAGES = "${PN}"
+INITSCRIPT_NAME = "load-firmware.py"
+INITSCRIPT_PARAMS = "defaults 01"
+
+RDEPENDS_${PN} = "python3-core"
+
+# install it in the correct location for update-rc.d
+do_install() {
+  install -d ${D}${INIT_D_DIR}
+  install -m 0755 ${WORKDIR}/load-firmware.py ${D}${INIT_D_DIR}/load-firmware.py
+  install -d ${D}/lib/firmware
+  install -m 0755 ${WORKDIR}/zfpga_top.bit ${D}/lib/firmware/zfpga_top.bit
+}
+
+# package it as it is not installed in a standard location
+FILES_${PN} = "\
+  ${INIT_D_DIR}/load-firmware.py \
+  /lib/firmware/zfpga_top.bit \
+"


### PR DESCRIPTION
Add recipe to load firmware onto zfpga on boot, is DISABLED by default, can be enabled by user at runtime or in a future build